### PR TITLE
[takea-look#4] Move, Zoom, Rotate the Text Component

### DIFF
--- a/memento/src/commonMain/kotlin/com/takealook/memento/Math.kt
+++ b/memento/src/commonMain/kotlin/com/takealook/memento/Math.kt
@@ -1,0 +1,23 @@
+package com.takealook.memento
+
+import androidx.compose.ui.geometry.Offset
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * calculate the actual offset of a rotated components.
+ * It uses Rotation Matrix.
+ */
+fun getRotatedPan(pan: Offset, rotationAmount: Float): Offset {
+    val radians = toRadians(rotationAmount)
+    val sin = sin(radians)
+    val cos = cos(radians)
+
+    val adjustedPan = Offset(
+        (pan.x * cos - pan.y * sin).toFloat(),
+        (pan.x * sin + pan.y * cos).toFloat()
+    )
+    return adjustedPan
+}
+
+fun toRadians(degrees: Float): Float = (degrees * kotlin.math.PI / 180f).toFloat()

--- a/memento/src/commonMain/kotlin/com/takealook/memento/MementoEditor.kt
+++ b/memento/src/commonMain/kotlin/com/takealook/memento/MementoEditor.kt
@@ -1,17 +1,27 @@
 package com.takealook.memento
 
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.isSpecified
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -39,24 +49,62 @@ fun MementoEditor(
             key(it.id) {
                 when (it) {
                     is MementoState.Text -> {
-                        val state = rememberTextFieldState(it.text)
-                        BasicTextField(
-                            state = state,
-                            modifier = Modifier
-                                .offset { IntOffset(it.offsetX.toInt(), it.offsetY.toInt()) }
-                                .pointerInput(Unit) {
-                                    detectTapGestures(
-                                        onTap = {
-                                            // TODO : Must be implemented
-                                        }
-                                    )
-                                }
+                        MementoTextField(
+                            state = it,
+                            onZoom = { zoom ->
+                                stateHolder.updateScale(it.id, zoom)
+                            },
+                            onDrag = { dragAmount ->
+                                stateHolder.updateLayout(it.id, dragAmount)
+                            },
+                            onRotate = { rotationDelta ->
+                                stateHolder.updateRotation(it.id, rotationDelta)
+                            }
                         )
                     }
                     else -> {} // TODO : Must be implemented
                 }
             }
         }
+    }
+}
+
+@Composable
+fun MementoTextField(
+    state: MementoState.Text,
+    onDrag: (dragAmount: Offset) -> Unit,
+    onZoom: (zoom: Float) -> Unit,
+    onRotate: (rotationDelta: Float) -> Float,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = TextStyle.Default,
+) {
+    val textState = rememberTextFieldState(state.text)
+    val baseFontSize = textStyle.fontSize.takeIf(TextUnit::isSpecified) ?: 50.sp
+    val scaledFontSize = (baseFontSize.value * state.scale).sp
+
+    Box(
+        modifier = modifier
+            .offset { IntOffset(state.offsetX.toInt(), state.offsetY.toInt()) }
+            .graphicsLayer {
+                rotationZ = state.rotation
+                transformOrigin = TransformOrigin.Center
+            }
+            .pointerInput(Unit) {
+                detectTransformGestures { _, pan, zoom, rotationDelta ->
+                    val updatedRotation = onRotate(rotationDelta)
+
+                    val adjustedPan = getRotatedPan(pan, updatedRotation)
+                    onDrag(adjustedPan)
+
+                    onZoom(zoom)
+                }
+            }
+    ) {
+        BasicTextField(
+            state = textState,
+            textStyle = textStyle.copy(fontSize = scaledFontSize, background = Color.Red),
+            modifier = Modifier.wrapContentWidth()
+        )
     }
 }
 

--- a/memento/src/commonMain/kotlin/com/takealook/memento/MementoState.kt
+++ b/memento/src/commonMain/kotlin/com/takealook/memento/MementoState.kt
@@ -3,8 +3,12 @@ package com.takealook.memento
 interface Layout {
     val offsetX: Float
     val offsetY: Float
+    val scale: Float
+    val rotation: Float
 
     fun updateLayout(offsetX: Float, offsetY: Float): MementoState
+    fun updateScale(scale: Float): MementoState
+    fun updateRotation(rotation: Float): MementoState
 }
 
 interface Identifiable {
@@ -15,10 +19,20 @@ sealed interface MementoState : Layout, Identifiable {
     data class Image(
         override val id: Int,
         override val offsetX: Float,
-        override val offsetY: Float
+        override val offsetY: Float,
+        override val scale: Float,
+        override val rotation: Float
     ) : MementoState {
         override fun updateLayout(offsetX: Float, offsetY: Float): MementoState {
             return copy(offsetX = offsetX, offsetY = offsetY)
+        }
+
+        override fun updateScale(scale: Float): MementoState {
+            return copy(scale = scale)
+        }
+
+        override fun updateRotation(rotation: Float): MementoState {
+            return copy(rotation = rotation)
         }
     }
 
@@ -26,7 +40,9 @@ sealed interface MementoState : Layout, Identifiable {
         val text: String,
         override val id: Int,
         override val offsetX: Float,
-        override val offsetY: Float
+        override val offsetY: Float,
+        override val scale: Float,
+        override val rotation: Float
     ) : MementoState {
         override fun updateLayout(offsetX: Float, offsetY: Float): MementoState {
             return copy(offsetX = offsetX, offsetY = offsetY)
@@ -35,15 +51,33 @@ sealed interface MementoState : Layout, Identifiable {
         fun updateText(text: String): MementoState {
             return copy(text = text)
         }
+
+        override fun updateScale(scale: Float): MementoState {
+            return copy(scale = scale)
+        }
+
+        override fun updateRotation(rotation: Float): MementoState {
+            return copy(rotation = rotation)
+        }
     }
 
     data class Sticker(
         override val id: Int,
         override val offsetX: Float,
-        override val offsetY: Float
+        override val offsetY: Float,
+        override val scale: Float,
+        override val rotation: Float
     ) : MementoState {
         override fun updateLayout(offsetX: Float, offsetY: Float): MementoState {
             return copy(offsetX = offsetX, offsetY = offsetY)
+        }
+
+        override fun updateScale(scale: Float): MementoState {
+            return copy(scale = scale)
+        }
+
+        override fun updateRotation(rotation: Float): MementoState {
+            return copy(rotation = rotation)
         }
     }
 }

--- a/memento/src/commonMain/kotlin/com/takealook/memento/MementoStateHolder.kt
+++ b/memento/src/commonMain/kotlin/com/takealook/memento/MementoStateHolder.kt
@@ -12,11 +12,42 @@ class MementoStateHolder {
     val state = _state.asStateFlow()
 }
 
-fun MementoStateHolder.updateLayout(id: Int, offset: Offset) {
+fun MementoStateHolder.updateRotation(id: Int, rotationDelta: Float): Float {
+    var updatedRotation = 0f
     val components = state.value.toMutableList()
     val updatedComponents = components.map {
         if (it.id == id) {
-            it.updateLayout(offsetX = offset.x, offsetY = offset.y)
+            updatedRotation = it.rotation + rotationDelta
+            it.updateRotation(updatedRotation)
+        } else it
+        }
+    components.clear()
+    components.addAll(updatedComponents)
+    _state.value = components
+
+    return updatedRotation
+}
+
+fun MementoStateHolder.updateScale(id: Int, scale: Float) {
+    val components = state.value.toMutableList()
+    val updatedComponents = components.map {
+        if (it.id == id) {
+            it.updateScale(it.scale * scale)
+        } else it
+    }
+    components.clear()
+    components.addAll(updatedComponents)
+    _state.value = components
+}
+
+fun MementoStateHolder.updateLayout(id: Int, dragAmount: Offset) {
+    val components = state.value.toMutableList()
+    val updatedComponents = components.map {
+        if (it.id == id) {
+            it.updateLayout(
+                offsetX = it.offsetX + dragAmount.x,
+                offsetY = it.offsetY + dragAmount.y
+            )
         } else it
     }
 
@@ -33,7 +64,9 @@ fun MementoStateHolder.createText(
         id = state.value.size + 1,
         text = initialText,
         offsetX = offset.x,
-        offsetY = offset.y
+        offsetY = offset.y,
+        scale = 1f,
+        rotation = 0f
     )
 
     _state.update { it + component }
@@ -44,7 +77,9 @@ fun MementoStateHolder.createImage(offset: Offset) {
     val component = MementoState.Image(
         id = state.value.size + 1,
         offsetX = 0f,
-        offsetY = 0f
+        offsetY = 0f,
+        scale = 1f,
+        rotation = 0f
     )
 
     _state.update { it + component }
@@ -55,7 +90,9 @@ fun MementoStateHolder.createSticker(offset: Offset) {
     val component = MementoState.Sticker(
         id = state.value.size + 1,
         offsetX = 0f,
-        offsetY = 0f
+        offsetY = 0f,
+        scale = 1f,
+        rotation = 0f
     )
 
     _state.update { it + component }


### PR DESCRIPTION
To move, rotate, zoom the components, we can use `detectTransformGestures` in `Modifier.pointerInput()`.

```kotlin
Modifier.pointerInput(Unit) {
    detectTransformGestures { _, pan, zoom, rotationDelta ->
        // update state here
        holder.updateRotation(rotationDelta) 
    }
}
```

To update this state, we can add property and function in the Layout interface defined previously.
```kotlin
interface Layout {  
    val offsetX: Float  
    val offsetY: Float  
    val scale: Float  
    val rotation: Float  
  
    fun updateLayout(offsetX: Float, offsetY: Float): MementoState  
    fun updateScale(scale: Float): MementoState  
    fun updateRotation(rotation: Float): MementoState  
}
```

And then, override these to update transform state.
```kotlin
sealed interface MementoState : Layout, Identifiable {  
	// ... 
	
    data class Text(  
        val text: String,  
        override val id: Int,  
        override val offsetX: Float,  
        override val offsetY: Float,  
        override val scale: Float,  
        override val rotation: Float  
    ) : MementoState {  
        override fun updateLayout(offsetX: Float, offsetY: Float): MementoState {  
            return copy(offsetX = offsetX, offsetY = offsetY)  
        }  
  
        fun updateText(text: String): MementoState {  
            return copy(text = text)  
        }  
  
        override fun updateScale(scale: Float): MementoState {  
            return copy(scale = scale)  
        }  
  
        override fun updateRotation(rotation: Float): MementoState {  
            return copy(rotation = rotation)
        }
    }
}
```
## problem in the rotated components
Fixed an issue where drag gestures caused components to move in an unexpected direction after rotation.
This was due to the drag offset (pan) being applied without accounting for the current rotation angle, which resulted in misaligned movement.

### AS-IS

https://github.com/user-attachments/assets/2b504cd5-d2bf-498b-a108-1cb84eeca302

### Fixed
The drag vector is now transformed using a 2D rotation matrix to match the rotated coordinate space of the component.

https://github.com/user-attachments/assets/0b53e6b7-6409-49bc-850c-3d32111f0f24

```kotlin
/**
 * calculate the actual offset of a rotated components.
 * It uses Rotation Matrix.
 */
fun getRotatedPan(pan: Offset, rotationAmount: Float): Offset {
    val radians = toRadians(rotationAmount)
    val sin = sin(radians)
    val cos = cos(radians)

    val adjustedPan = Offset(
        (pan.x * cos - pan.y * sin).toFloat(),
        (pan.x * sin + pan.y * cos).toFloat()
    )
    return adjustedPan
}

fun toRadians(degrees: Float): Float = (degrees * kotlin.math.PI / 180f).toFloat()

```