### PR TITLE
Fix MementoEditor text focus and keyboard interaction

### DIFF
--- a/memento-ui/src/commonMain/kotlin/my/takealook/memento/MementoEditor.kt
+++ b/memento-ui/src/commonMain/kotlin/my/takealook/memento/MementoEditor.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -138,25 +139,12 @@ fun MementoEditor(
                 )
             }
     ) {
-        // Main Content Image
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .align(Alignment.Center)
-                .onGloballyPositioned {
-                    imageRect = it.boundsInParent()
-                }
-            ,
-            content = mainContent
-        )
-
         // TextField for Edit Mode
         if (requestText) {
             MementoTextField(
                 state = newTextState,
                 modifier = Modifier
-                    .offset { IntOffset(focusOffset.x.toInt(), 0) }
-                    .align(Alignment.CenterStart)
+                    .offset { IntOffset(focusOffset.x.toInt(), focusOffset.y.toInt()) }
                     .onGloballyPositioned {
                         newTextOffset = it.positionInParent()
                     }
@@ -169,6 +157,18 @@ fun MementoEditor(
                 )
             )
         }
+
+        // Main Content Image
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.Center)
+                .onGloballyPositioned {
+                    imageRect = it.boundsInParent()
+                }
+            ,
+            content = mainContent
+        )
 
         if (isTextFocused) {
             FocusModeScreen(
@@ -198,7 +198,8 @@ fun MementoEditor(
             MementoRainbowPalette(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
-                    .zIndex(1001F),
+                    .zIndex(1001F)
+                    .imePadding(),
                 onColorClick = {
                     if (stateHolder.focusId != null) {
                         stateHolder.updateText(stateHolder.focusId!!, it)


### PR DESCRIPTION
This commit addresses issues with text field focus and keyboard interaction within the MementoEditor:

- **TextField Positioning:** The MementoTextField is now correctly positioned when focused, ensuring it's not obscured.
- **Keyboard Padding:** The MementoRainbowPalette now includes `imePadding()`, preventing it from being covered by the on-screen keyboard.
- **Layout Order:** The main content image is now rendered after the TextField to ensure proper layering and prevent focus issues.